### PR TITLE
Upgrade to Resonate SDK v0.10.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ vite.config.ts.timestamp-*
 .cursor
 resonate.db
 *.lock
+package-lock.json
+.DS_Store

--- a/factorialClient.ts
+++ b/factorialClient.ts
@@ -1,7 +1,8 @@
 import { Resonate } from "@resonatehq/sdk";
 import assert from "assert";
 
-const resonate = Resonate.remote({
+const resonate = new Resonate({
+  url: "http://localhost:8001",
   group: "factorial-client",
 });
 

--- a/factorialWorker.ts
+++ b/factorialWorker.ts
@@ -1,7 +1,8 @@
-import { Resonate, Context } from "@resonatehq/sdk";
+import { Resonate, type Context } from "@resonatehq/sdk";
 import assert from "assert";
 
-const resonate = Resonate.remote({
+const resonate = new Resonate({
+  url: "http://localhost:8001",
   group: "factorial-workers",
 });
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@resonatehq/sdk": ">=0.8.0"
+    "@resonatehq/sdk": "^0.10.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,29 +1,17 @@
 {
   "compilerOptions": {
-    // Environment setup & latest features
     "lib": ["ESNext"],
     "target": "ESNext",
     "module": "Preserve",
     "moduleDetection": "force",
-    "jsx": "react-jsx",
-    "allowJs": true,
-
-    // Bundler mode
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": false,
+    "verbatimModuleSyntax": true,
     "noEmit": true,
-
-    // Best practices
     "strict": true,
     "skipLibCheck": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-
-    // Some stricter flags (disabled by default)
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noPropertyAccessFromIndexSignature": false
+    "noImplicitOverride": true
   }
 }


### PR DESCRIPTION
## Summary

- Upgrades to Resonate SDK v0.10.0
- Updates dependencies and source files accordingly

## Test plan

- [ ] Build passes
- [ ] Example runs as expected with Resonate SDK v0.10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)