### PR TITLE
readme: example-app — competitor-rewrite (iter-44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ That is — when a function is invoked, a single Durable Promise is created.
 The Durable Promise represents the invocation event.
 And it remains in a PENDING state until it is either RESOLVED with a result or REJECTED by the business process.
 
-This means that there is no distinction between "workflow" functions and "step"/"activity" functions. There are just Durable Functions.
+This means that there is no distinction between "workflow" functions and "step"/"activity" functions. Every function invocation is durable by default.
 
 And this means it is relatively trivial for a function to call itself recursively without the code looking messy, and without that operation being expensive in terms of bloating an event history and unnecessary network calls.
 


### PR DESCRIPTION
Scope: SPEC §4.4.a, concern `competitor-rewrite`, README.md only.

Removed 1 "Durable Functions" mention:
- `"There are just Durable Functions."` (capitalized — reads as the Azure Durable Functions brand per SPEC §3.4 banned-name list) replaced with `"Every function invocation is durable by default."` — preserves the original intent (no workflow/activity split) without the branded phrasing

Post-edit grep: 0 competitor mentions (was 1).

Note: no staged banner PR on `brand/readme-banner` for this repo; curation PR stands independently.

Refs: SPEC §3.4 + §4.4.a; OPEN.md #2; PROPAGATION-BACKLOG #6.